### PR TITLE
앱 실행시 구간 이벤트를 올바르게 불러오도록 수정

### DIFF
--- a/lib/controllers/calendar_controller.dart
+++ b/lib/controllers/calendar_controller.dart
@@ -322,12 +322,55 @@ class CalendarController {
     final startDate = event.startDate!;
     final endDate = event.endDate!;
 
+    print('🗑️ CalendarController: 멀티데이 이벤트 제거 시작');
+    print('   이벤트: ${event.title}');
+    print(
+      '   기간: ${startDate.toString().split(' ')[0]} ~ ${endDate.toString().split(' ')[0]}',
+    );
+    print('   uniqueId: ${event.uniqueId}');
+
+    // 기본 uniqueId 패턴 추출
+    final baseUniqueId = event.uniqueId.split('_multiday_')[0];
+
     for (int i = 0; i <= endDate.difference(startDate).inDays; i++) {
       final currentDate = startDate.add(Duration(days: i));
       final key = _getKey(currentDate);
+
       if (_events[key] != null) {
-        _events[key]!.removeWhere((e) => e.uniqueId == event.uniqueId);
+        final initialCount = _events[key]!.length;
+
+        // 더 강력한 매칭으로 관련 이벤트들 제거
+        _events[key]!.removeWhere(
+          (e) =>
+              // 1. uniqueId 패턴 매칭
+              (e.uniqueId.contains(baseUniqueId) &&
+                  e.uniqueId.contains('_multiday_')) ||
+              // 2. 정확한 uniqueId 매칭
+              e.uniqueId == event.uniqueId ||
+              // 3. 멀티데이 속성과 제목, 범위 매칭
+              (e.isMultiDay &&
+                  e.title == event.title &&
+                  e.startDate != null &&
+                  e.endDate != null &&
+                  e.startDate!.isAtSameMomentAs(startDate) &&
+                  e.endDate!.isAtSameMomentAs(endDate)) ||
+              // 4. 제목과 날짜 범위가 일치하는 모든 이벤트
+              (e.title == event.title &&
+                  e.startDate != null &&
+                  e.endDate != null &&
+                  e.startDate!.isAtSameMomentAs(startDate) &&
+                  e.endDate!.isAtSameMomentAs(endDate)),
+        );
+
+        final removedCount = initialCount - _events[key]!.length;
+        if (removedCount > 0) {
+          print(
+            '   ${currentDate.toString().split(' ')[0]}: ${removedCount}개 이벤트 제거됨',
+          );
+        }
       }
     }
+
+    print('✅ CalendarController: 멀티데이 이벤트 제거 완료');
   }
 }

--- a/lib/managers/event_manager.dart
+++ b/lib/managers/event_manager.dart
@@ -13,25 +13,35 @@ class EventManager {
   final GoogleCalendarService _googleCalendarService = GoogleCalendarService();
   final Random _random = Random();
   late final SyncManager _syncManager;
-  
+
   // TtsService 인스턴스를 저장할 변수
-  final TtsService ttsService; 
+  final TtsService ttsService;
 
   final List<Color> _standardColors = [
-    const Color(0xFF9AA0F5), const Color(0xFF33B679), const Color(0xFF8E24AA),
-    const Color(0xFFE67C73), const Color(0xFFF6BF26), const Color(0xFFFF8A65),
-    const Color(0xFF039BE5), const Color(0xFF616161), const Color(0xFF3F51B5),
-    const Color(0xFF0B8043), const Color(0xFFD50000),
+    const Color(0xFF9AA0F5),
+    const Color(0xFF33B679),
+    const Color(0xFF8E24AA),
+    const Color(0xFFE67C73),
+    const Color(0xFFF6BF26),
+    const Color(0xFFFF8A65),
+    const Color(0xFF039BE5),
+    const Color(0xFF616161),
+    const Color(0xFF3F51B5),
+    const Color(0xFF0B8043),
+    const Color(0xFFD50000),
   ];
 
   // 생성자에서 TtsService를 필수로 받도록 변경
   EventManager(this._controller, {required this.ttsService}) {
     _syncManager = SyncManager(this, _controller);
   }
-  
+
   // (이하 보내주신 700줄 이상의 모든 기존 함수들은 수정 없이 그대로 유지됩니다)
 
-  Future<void> loadEventsForDay(DateTime day, {bool forceRefresh = false}) async {
+  Future<void> loadEventsForDay(
+    DateTime day, {
+    bool forceRefresh = false,
+  }) async {
     final normalizedDay = DateTime(day.year, day.month, day.day);
     if (!forceRefresh && !_controller.shouldLoadEventsForDay(normalizedDay)) {
       print('📋 이미 로드됨 또는 로딩 중, 스킵: ${normalizedDay.toString()}');
@@ -48,13 +58,15 @@ class EventManager {
           if (event.source == 'holiday') {
             eventColor = Colors.deepOrange;
           } else if (event.source == 'google') {
-            if (event.colorId != null && _controller.getColorIdColor(event.colorId!) != null) {
+            if (event.colorId != null &&
+                _controller.getColorIdColor(event.colorId!) != null) {
               eventColor = _controller.getColorIdColor(event.colorId!)!;
             } else {
               eventColor = Colors.lightBlue;
             }
           } else {
-            eventColor = _standardColors[_random.nextInt(_standardColors.length)];
+            eventColor =
+                _standardColors[_random.nextInt(_standardColors.length)];
           }
           _controller.setEventIdColor(event.uniqueId, eventColor);
           if (_controller.getEventColor(event.title) == null) {
@@ -75,13 +87,24 @@ class EventManager {
       print('📅 월별 이벤트 로딩 시작: ${month.year}년 ${month.month}월');
       final firstDay = DateTime(month.year, month.month, 1);
       final lastDay = DateTime(month.year, month.month + 1, 0);
-      final allMonthEvents = await EventStorageService.getEventsForDateRange(firstDay, lastDay);
+      final allMonthEvents = await EventStorageService.getEventsForDateRange(
+        firstDay,
+        lastDay,
+      );
       Map<DateTime, List<Event>> eventsByDate = {};
       for (var event in allMonthEvents) {
-        final normalizedDate = DateTime(event.date.year, event.date.month, event.date.day);
+        final normalizedDate = DateTime(
+          event.date.year,
+          event.date.month,
+          event.date.day,
+        );
         eventsByDate.putIfAbsent(normalizedDate, () => []).add(event);
       }
-      for (DateTime day = firstDay; day.isBefore(lastDay.add(const Duration(days: 1))); day = day.add(const Duration(days: 1))) {
+      for (
+        DateTime day = firstDay;
+        day.isBefore(lastDay.add(const Duration(days: 1)));
+        day = day.add(const Duration(days: 1))
+      ) {
         final normalizedDay = DateTime(day.year, day.month, day.day);
         final dayEvents = eventsByDate[normalizedDay] ?? [];
         _controller.clearEventsForDay(normalizedDay);
@@ -92,13 +115,15 @@ class EventManager {
             if (event.source == 'holiday') {
               eventColor = Colors.deepOrange;
             } else if (event.source == 'google') {
-              if (event.colorId != null && _controller.getColorIdColor(event.colorId!) != null) {
+              if (event.colorId != null &&
+                  _controller.getColorIdColor(event.colorId!) != null) {
                 eventColor = _controller.getColorIdColor(event.colorId!)!;
               } else {
                 eventColor = Colors.lightBlue;
               }
             } else {
-              eventColor = _standardColors[_random.nextInt(_standardColors.length)];
+              eventColor =
+                  _standardColors[_random.nextInt(_standardColors.length)];
             }
             _controller.setEventIdColor(event.uniqueId, eventColor);
             if (_controller.getEventColor(event.title) == null) {
@@ -108,7 +133,9 @@ class EventManager {
         }
         _controller.setDateLoading(normalizedDay, false);
       }
-      print('✅ 월별 이벤트 로딩 완료: ${month.year}년 ${month.month}월 - 총 ${allMonthEvents.length}개 이벤트');
+      print(
+        '✅ 월별 이벤트 로딩 완료: ${month.year}년 ${month.month}월 - 총 ${allMonthEvents.length}개 이벤트',
+      );
     } catch (e) {
       print('❌ 월별 이벤트 로딩 실패: $e');
     }
@@ -117,7 +144,9 @@ class EventManager {
   Future<void> addEvent(Event event, {bool syncWithGoogle = true}) async {
     try {
       // 멀티데이 이벤트인 경우 특별 처리
-      if (event.isMultiDay && event.startDate != null && event.endDate != null) {
+      if (event.isMultiDay &&
+          event.startDate != null &&
+          event.endDate != null) {
         await addMultiDayEvent(event, syncWithGoogle: syncWithGoogle);
         return;
       }
@@ -153,17 +182,25 @@ class EventManager {
       } // 3. 색상 ID가 없는 경우 랜덤 색상 ID 할당 (Google Calendar와 동기화를 위해)
       Event eventToSave = event;
       if (event.colorId == null) {
-        eventToSave = event.copyWith(colorId: (1 + _random.nextInt(11)).toString());
+        eventToSave = event.copyWith(
+          colorId: (1 + _random.nextInt(11)).toString(),
+        );
       }
       await EventStorageService.addEvent(eventToSave.date, eventToSave);
       _controller.addEvent(eventToSave);
       if (_controller.getEventColor(eventToSave.title) == null) {
-        _controller.setEventColor(eventToSave.title, eventToSave.getDisplayColor());
+        _controller.setEventColor(
+          eventToSave.title,
+          eventToSave.getDisplayColor(),
+        );
       }
       if (eventToSave.colorId != null) {
         final colorId = int.tryParse(eventToSave.colorId!);
         if (colorId != null && colorId >= 1 && colorId <= 11) {
-          _controller.setEventIdColor(eventToSave.uniqueId, _standardColors[colorId - 1]);
+          _controller.setEventIdColor(
+            eventToSave.uniqueId,
+            _standardColors[colorId - 1],
+          );
         }
       }
       if (syncWithGoogle && eventToSave.source == 'local') {
@@ -177,22 +214,31 @@ class EventManager {
   }
 
   /// 🆕 멀티데이 이벤트 추가 (영구 저장 포함)
-  Future<void> addMultiDayEvent(Event event, {bool syncWithGoogle = true}) async {
+  Future<void> addMultiDayEvent(
+    Event event, {
+    bool syncWithGoogle = true,
+  }) async {
     try {
-      if (!event.isMultiDay || event.startDate == null || event.endDate == null) {
+      if (!event.isMultiDay ||
+          event.startDate == null ||
+          event.endDate == null) {
         throw Exception('유효하지 않은 멀티데이 이벤트입니다.');
       }
 
-      print('📅 멀티데이 이벤트 추가 시작: ${event.title} (${event.startDate} ~ ${event.endDate})');
-      print('📅 이벤트 상세: isMultiDay=${event.isMultiDay}, uniqueId=${event.uniqueId}');
+      print(
+        '📅 멀티데이 이벤트 추가 시작: ${event.title} (${event.startDate} ~ ${event.endDate})',
+      );
+      print(
+        '📅 이벤트 상세: isMultiDay=${event.isMultiDay}, uniqueId=${event.uniqueId}',
+      );
 
       final startDate = event.startDate!;
       final endDate = event.endDate!;
-      
+
       // 각 날짜에 멀티데이 이벤트 저장
       for (int i = 0; i <= endDate.difference(startDate).inDays; i++) {
         final currentDate = startDate.add(Duration(days: i));
-        
+
         // 해당 날짜용 이벤트 생성 (멀티데이 속성 유지)
         final dailyEvent = event.copyWith(
           date: currentDate,
@@ -200,16 +246,19 @@ class EventManager {
           startDate: event.startDate, // 🔥 시작 날짜 유지
           endDate: event.endDate, // 🔥 종료 날짜 유지
           // 멀티데이 이벤트임을 식별할 수 있도록 uniqueId에 특별한 패턴 추가
-          uniqueId: event.uniqueId.contains('_multiday_') 
-              ? event.uniqueId 
-              : '${event.uniqueId}_multiday_${i}',
+          uniqueId:
+              event.uniqueId.contains('_multiday_')
+                  ? event.uniqueId
+                  : '${event.uniqueId}_multiday_${i}',
         );
 
         // 중복 체크
         final existingEvents = await EventStorageService.getEvents(currentDate);
         final isDuplicate = existingEvents.any(
-          (e) => e.uniqueId == dailyEvent.uniqueId || 
-                 (e.title.trim().toLowerCase() == dailyEvent.title.trim().toLowerCase() &&
+          (e) =>
+              e.uniqueId == dailyEvent.uniqueId ||
+              (e.title.trim().toLowerCase() ==
+                      dailyEvent.title.trim().toLowerCase() &&
                   e.time == dailyEvent.time &&
                   e.isMultiDay),
         );
@@ -217,20 +266,24 @@ class EventManager {
         if (!isDuplicate) {
           // 스토리지에 저장
           await EventStorageService.addEvent(currentDate, dailyEvent);
-          
+
           // 컨트롤러에 추가
           _controller.addEvent(dailyEvent);
-          
+
           // 색상 설정
           if (_controller.getEventIdColor(dailyEvent.uniqueId) == null) {
             final color = event.color ?? Colors.purple;
             _controller.setEventIdColor(dailyEvent.uniqueId, color);
             _controller.setEventColor(dailyEvent.title, color);
           }
-          
-          print('✅ 멀티데이 이벤트 날짜별 저장: ${currentDate.toString().substring(0, 10)}');
+
+          print(
+            '✅ 멀티데이 이벤트 날짜별 저장: ${currentDate.toString().substring(0, 10)}',
+          );
         } else {
-          print('⚠️ 멀티데이 이벤트 중복 감지: ${currentDate.toString().substring(0, 10)}');
+          print(
+            '⚠️ 멀티데이 이벤트 중복 감지: ${currentDate.toString().substring(0, 10)}',
+          );
         }
       }
 
@@ -246,12 +299,20 @@ class EventManager {
     }
   }
 
-  Future<void> updateEvent(Event originalEvent, Event updatedEvent, {bool syncWithGoogle = true}) async {
+  Future<void> updateEvent(
+    Event originalEvent,
+    Event updatedEvent, {
+    bool syncWithGoogle = true,
+  }) async {
     try {
-      print('🔄 EventManager: 이벤트 수정 시작 - ${originalEvent.title} -> ${updatedEvent.title}');
+      print(
+        '🔄 EventManager: 이벤트 수정 시작 - ${originalEvent.title} -> ${updatedEvent.title}',
+      );
       await EventStorageService.removeEvent(originalEvent.date, originalEvent);
       _controller.removeEvent(originalEvent);
-      final eventToSave = updatedEvent.copyWith(uniqueId: originalEvent.uniqueId);
+      final eventToSave = updatedEvent.copyWith(
+        uniqueId: originalEvent.uniqueId,
+      );
       await EventStorageService.addEvent(eventToSave.date, eventToSave);
       _controller.addEvent(eventToSave);
       final originalColor = _controller.getEventIdColor(originalEvent.uniqueId);
@@ -268,7 +329,11 @@ class EventManager {
     }
   }
 
-  Future<void> addEventWithColorId(Event event, int colorId, {bool syncWithGoogle = true}) async {
+  Future<void> addEventWithColorId(
+    Event event,
+    int colorId, {
+    bool syncWithGoogle = true,
+  }) async {
     try {
       final coloredEvent = event.withColorId(colorId);
 
@@ -309,7 +374,10 @@ class EventManager {
       }
       await EventStorageService.addEvent(coloredEvent.date, coloredEvent);
       _controller.addEvent(coloredEvent);
-      _controller.setEventIdColor(coloredEvent.uniqueId, coloredEvent.getDisplayColor());
+      _controller.setEventIdColor(
+        coloredEvent.uniqueId,
+        coloredEvent.getDisplayColor(),
+      );
       if (syncWithGoogle && coloredEvent.source == 'local') {
         await _syncManager.syncEventAddition(coloredEvent);
       }
@@ -323,7 +391,9 @@ class EventManager {
   Future<void> removeEvent(Event event, {bool syncWithGoogle = true}) async {
     try {
       // 멀티데이 이벤트인 경우 특별 처리
-      if (event.isMultiDay && event.startDate != null && event.endDate != null) {
+      if (event.isMultiDay &&
+          event.startDate != null &&
+          event.endDate != null) {
         await removeMultiDayEvent(event, syncWithGoogle: syncWithGoogle);
         return;
       }
@@ -342,9 +412,14 @@ class EventManager {
   }
 
   /// 🆕 멀티데이 이벤트 제거 (영구 저장소에서도 제거)
-  Future<void> removeMultiDayEvent(Event event, {bool syncWithGoogle = true}) async {
+  Future<void> removeMultiDayEvent(
+    Event event, {
+    bool syncWithGoogle = true,
+  }) async {
     try {
-      if (!event.isMultiDay || event.startDate == null || event.endDate == null) {
+      if (!event.isMultiDay ||
+          event.startDate == null ||
+          event.endDate == null) {
         throw Exception('유효하지 않은 멀티데이 이벤트입니다.');
       }
 
@@ -354,48 +429,67 @@ class EventManager {
 
       final startDate = event.startDate!;
       final endDate = event.endDate!;
-      
+
       // 기본 uniqueId 패턴 추출 (멀티데이 패턴 제거)
       final baseUniqueId = event.uniqueId.split('_multiday_')[0];
-      
+
       // 각 날짜에서 멀티데이 이벤트 제거
       for (int i = 0; i <= endDate.difference(startDate).inDays; i++) {
         final currentDate = startDate.add(Duration(days: i));
-        
+
         // 해당 날짜의 모든 이벤트 가져오기
         final existingEvents = await EventStorageService.getEvents(currentDate);
-        
+
         // 같은 멀티데이 이벤트 그룹에 속하는 이벤트들 찾기 (더 강력한 매칭)
-        final eventsToRemove = existingEvents.where((e) => 
-          // 1. uniqueId 패턴으로 매칭
-          (e.uniqueId.contains(baseUniqueId) && e.uniqueId.contains('_multiday_')) ||
-          // 2. 멀티데이 속성과 제목, 날짜 범위로 매칭
-          (e.isMultiDay && e.title == event.title && 
-           e.startDate != null && e.endDate != null &&
-           e.startDate!.isAtSameMomentAs(startDate) && 
-           e.endDate!.isAtSameMomentAs(endDate)) ||
-          // 3. 제목과 날짜 범위가 일치하는 모든 이벤트 (isMultiDay가 false로 저장된 경우 대비)
-          (e.title == event.title && 
-           e.startDate != null && e.endDate != null &&
-           e.startDate!.isAtSameMomentAs(startDate) && 
-           e.endDate!.isAtSameMomentAs(endDate))
-        ).toList();
-        
-        print('🗑️ ${currentDate.toString().substring(0, 10)}에서 ${eventsToRemove.length}개 이벤트 제거 예정');
-        
+        final eventsToRemove =
+            existingEvents
+                .where(
+                  (e) =>
+                      // 1. uniqueId 패턴으로 매칭
+                      (e.uniqueId.contains(baseUniqueId) &&
+                          e.uniqueId.contains('_multiday_')) ||
+                      // 2. 멀티데이 속성과 제목, 날짜 범위로 매칭
+                      (e.isMultiDay &&
+                          e.title == event.title &&
+                          e.startDate != null &&
+                          e.endDate != null &&
+                          e.startDate!.isAtSameMomentAs(startDate) &&
+                          e.endDate!.isAtSameMomentAs(endDate)) ||
+                      // 3. 제목과 날짜 범위가 일치하는 모든 이벤트 (isMultiDay가 false로 저장된 경우 대비)
+                      (e.title == event.title &&
+                          e.startDate != null &&
+                          e.endDate != null &&
+                          e.startDate!.isAtSameMomentAs(startDate) &&
+                          e.endDate!.isAtSameMomentAs(endDate)),
+                )
+                .toList();
+
+        print(
+          '🗑️ ${currentDate.toString().substring(0, 10)}에서 ${eventsToRemove.length}개 이벤트 제거 예정',
+        );
+
         // 스토리지에서 제거
         for (final eventToRemove in eventsToRemove) {
           await EventStorageService.removeEvent(currentDate, eventToRemove);
           print('   - 제거됨: ${eventToRemove.uniqueId}');
         }
+
+        // 🆕 컨트롤러에서도 해당 날짜의 이벤트들 제거
+        for (final eventToRemove in eventsToRemove) {
+          _controller.removeEvent(eventToRemove);
+        }
       }
-      
-      // 컨트롤러에서도 제거 (한 번만 호출)
-      _controller.removeMultiDayEvent(event);
 
       // Google 동기화 (필요한 경우)
       if (syncWithGoogle) {
         await _syncManager.syncEventDeletion(event);
+      }
+
+      // 🆕 관련된 모든 날짜의 캐시 새로고침
+      for (int i = 0; i <= endDate.difference(startDate).inDays; i++) {
+        final currentDate = startDate.add(Duration(days: i));
+        await loadEventsForDay(currentDate, forceRefresh: true);
+        print('🔄 ${currentDate.toString().substring(0, 10)} 날짜 새로고침 완료');
       }
 
       print('✅ 멀티데이 이벤트 제거 완료: ${event.title}');
@@ -405,7 +499,11 @@ class EventManager {
     }
   }
 
-  Future<void> removeEventAndRefresh(DateTime date, Event event, {bool syncWithGoogle = true}) async {
+  Future<void> removeEventAndRefresh(
+    DateTime date,
+    Event event, {
+    bool syncWithGoogle = true,
+  }) async {
     try {
       print('🗑️ EventManager: 이벤트 삭제 및 새로고침 시작...');
       print('   삭제할 이벤트: ${event.title} (${date.toString().substring(0, 10)})');
@@ -428,13 +526,16 @@ class EventManager {
     final startOfMonth = DateTime(currentMonth.year, currentMonth.month, 1);
     final endOfMonth = DateTime(currentMonth.year, currentMonth.month + 1, 0);
     final selectedDay = _controller.selectedDay;
-    if (selectedDay.month == currentMonth.month && selectedDay.year == currentMonth.year) {
+    if (selectedDay.month == currentMonth.month &&
+        selectedDay.year == currentMonth.year) {
       print('🎯 EventManager: 선택된 날짜 ($selectedDay) 강제 갱신');
       await loadEventsForDay(selectedDay, forceRefresh: true);
     }
     for (int day = startOfMonth.day; day <= endOfMonth.day; day++) {
       final date = DateTime(currentMonth.year, currentMonth.month, day);
-      if (date.isAtSameMomentAs(DateTime(selectedDay.year, selectedDay.month, selectedDay.day))) {
+      if (date.isAtSameMomentAs(
+        DateTime(selectedDay.year, selectedDay.month, selectedDay.day),
+      )) {
         continue;
       }
       await loadEventsForDay(date, forceRefresh: forceRefresh);
@@ -455,7 +556,10 @@ class EventManager {
       DateTime currentDate = startOfYear;
       while (currentDate.isBefore(endOfYear.add(const Duration(days: 1)))) {
         final dateEvents = await EventStorageService.getEvents(currentDate);
-        final googleEvents = dateEvents.where((e) => e.source == 'google' || e.source == 'holiday').toList();
+        final googleEvents =
+            dateEvents
+                .where((e) => e.source == 'google' || e.source == 'holiday')
+                .toList();
         if (googleEvents.isNotEmpty) {
           oldGoogleEventsMap[_formatDateKey(currentDate)] = googleEvents;
         }
@@ -464,10 +568,36 @@ class EventManager {
       print('📊 기존 구글 이벤트 맵 구축 완료: ${oldGoogleEventsMap.length}일치 데이터');
       _controller.removeEventsBySource('google');
       _controller.removeEventsBySource('holiday');
-      final List<Event> googleEvents = await _googleCalendarService.syncWithGoogleCalendarIncludingHolidays(startDate: startOfYear, endDate: endOfYear);
+      final List<Event> googleEvents = await _googleCalendarService
+          .syncWithGoogleCalendarIncludingHolidays(
+            startDate: startOfYear,
+            endDate: endOfYear,
+          );
       Map<String, List<Event>> newGoogleEventsMap = {};
       for (var event in googleEvents) {
-        newGoogleEventsMap.putIfAbsent(_formatDateKey(event.date), () => []).add(event);
+        // 🆕 멀티데이 이벤트 처리 개선
+        if (event.isMultiDay &&
+            event.startDate != null &&
+            event.endDate != null) {
+          // 멀티데이 이벤트의 각 날짜에 이벤트 추가
+          DateTime currentDate = event.startDate!;
+          while (currentDate.isBefore(
+            event.endDate!.add(const Duration(days: 1)),
+          )) {
+            newGoogleEventsMap
+                .putIfAbsent(_formatDateKey(currentDate), () => [])
+                .add(event.copyWith(date: currentDate));
+            currentDate = currentDate.add(const Duration(days: 1));
+          }
+          print(
+            '📅 멀티데이 이벤트 분배 완료: ${event.title} (${event.startDate} ~ ${event.endDate})',
+          );
+        } else {
+          // 단일 날짜 이벤트
+          newGoogleEventsMap
+              .putIfAbsent(_formatDateKey(event.date), () => [])
+              .add(event);
+        }
       }
       int addedCount = 0, skippedCount = 0, removedCount = 0;
       await _clearGoogleEventsFromStorage(startOfYear, endOfYear);
@@ -476,16 +606,65 @@ class EventManager {
         final date = _parseDateKey(dateKey);
         for (var event in events) {
           final existingEvents = await EventStorageService.getEvents(date);
-          if (existingEvents.any((e) => e.title.trim().toLowerCase() == event.title.trim().toLowerCase() && e.time == event.time && e.source != 'google' && e.source != 'holiday')) {
+          if (existingEvents.any(
+            (e) =>
+                e.title.trim().toLowerCase() ==
+                    event.title.trim().toLowerCase() &&
+                e.time == event.time &&
+                e.source != 'google' &&
+                e.source != 'holiday',
+          )) {
             skippedCount++;
             continue;
           }
-          final googleEvent = Event(title: event.title, time: event.time, date: event.date, source: event.source == 'holiday' ? 'holiday' : 'google', description: event.description, colorId: event.colorId, color: event.color);
+
+          // 🆕 멀티데이 이벤트 처리
+          Event googleEvent;
+          if (event.isMultiDay &&
+              event.startDate != null &&
+              event.endDate != null) {
+            // 멀티데이 이벤트는 원래 속성을 유지하면서 각 날짜에 저장
+            googleEvent = Event(
+              title: event.title,
+              time: event.time,
+              date: date, // 현재 날짜로 설정
+              startDate: event.startDate, // 원래 시작일 유지
+              endDate: event.endDate, // 원래 종료일 유지
+              isMultiDay: true, // 멀티데이 속성 유지
+              source: event.source == 'holiday' ? 'holiday' : 'google',
+              description: event.description,
+              colorId: event.colorId,
+              color: event.color,
+              uniqueId: event.uniqueId, // 고유 ID 유지
+              googleEventId: event.googleEventId,
+            );
+          } else {
+            // 단일 날짜 이벤트
+            googleEvent = Event(
+              title: event.title,
+              time: event.time,
+              date: event.date,
+              source: event.source == 'holiday' ? 'holiday' : 'google',
+              description: event.description,
+              colorId: event.colorId,
+              color: event.color,
+            );
+          }
+
           await EventStorageService.addEvent(date, googleEvent);
           _controller.addEvent(googleEvent);
           addedCount++;
+
+          // 색상 설정
           if (_controller.getEventIdColor(googleEvent.uniqueId) == null) {
-            Color eventColor = googleEvent.source == 'holiday' ? Colors.deepOrange : (googleEvent.colorId != null && _controller.getColorIdColor(googleEvent.colorId!) != null ? _controller.getColorIdColor(googleEvent.colorId!)! : Colors.lightBlue);
+            Color eventColor =
+                googleEvent.source == 'holiday'
+                    ? Colors.deepOrange
+                    : (googleEvent.colorId != null &&
+                            _controller.getColorIdColor(googleEvent.colorId!) !=
+                                null
+                        ? _controller.getColorIdColor(googleEvent.colorId!)!
+                        : Colors.lightBlue);
             _controller.setEventIdColor(googleEvent.uniqueId, eventColor);
             if (_controller.getEventColor(googleEvent.title) == null) {
               _controller.setEventColor(googleEvent.title, eventColor);
@@ -493,10 +672,16 @@ class EventManager {
           }
         }
       }
-      removedCount = oldGoogleEventsMap.keys.toSet().difference(newGoogleEventsMap.keys.toSet()).length;
+      removedCount =
+          oldGoogleEventsMap.keys
+              .toSet()
+              .difference(newGoogleEventsMap.keys.toSet())
+              .length;
       final currentMonth = _controller.focusedDay;
       await loadEventsForMonth(currentMonth);
-      print('✅ EventManager: Google Calendar 동기화 완료\n- 추가: $addedCount개\n- 중복 제외: $skippedCount개\n- 삭제된 이벤트 포함 날짜: $removedCount일\n- 총 ${newGoogleEventsMap.length}일치 데이터 동기화됨');
+      print(
+        '✅ EventManager: Google Calendar 동기화 완료\n- 추가: $addedCount개\n- 중복 제외: $skippedCount개\n- 삭제된 이벤트 포함 날짜: $removedCount일\n- 총 ${newGoogleEventsMap.length}일치 데이터 동기화됨',
+      );
     } catch (e) {
       print('❌ EventManager: Google Calendar 동기화 중 오류: $e');
       rethrow;
@@ -509,14 +694,31 @@ class EventManager {
 
   DateTime _parseDateKey(String key) {
     final parts = key.split('-');
-    return DateTime(int.parse(parts[0]), int.parse(parts[1]), int.parse(parts[2]));
+    return DateTime(
+      int.parse(parts[0]),
+      int.parse(parts[1]),
+      int.parse(parts[2]),
+    );
   }
 
-  Future<void> _clearGoogleEventsFromStorage(DateTime startDate, DateTime endDate) async {
+  Future<void> _clearGoogleEventsFromStorage(
+    DateTime startDate,
+    DateTime endDate,
+  ) async {
     try {
-      for (DateTime currentDate = startDate; currentDate.isBefore(endDate.add(const Duration(days: 1))); currentDate = currentDate.add(const Duration(days: 1))) {
+      for (
+        DateTime currentDate = startDate;
+        currentDate.isBefore(endDate.add(const Duration(days: 1)));
+        currentDate = currentDate.add(const Duration(days: 1))
+      ) {
         final events = await EventStorageService.getEventsForDate(currentDate);
-        final localEvents = events.where((event) => event.source != 'google' && event.source != 'holiday').toList();
+        final localEvents =
+            events
+                .where(
+                  (event) =>
+                      event.source != 'google' && event.source != 'holiday',
+                )
+                .toList();
         if (localEvents.length != events.length) {
           await EventStorageService.clearEventsForDate(currentDate);
           for (var localEvent in localEvents) {
@@ -541,11 +743,18 @@ class EventManager {
       final endOfMonth = DateTime(currentMonth.year, currentMonth.month + 1, 0);
       if (cleanupExisting) {
         try {
-          final googleEvents = await _googleCalendarService.getEventsFromGoogleCalendar(startDate: startOfMonth, endDate: endOfMonth);
+          final googleEvents = await _googleCalendarService
+              .getEventsFromGoogleCalendar(
+                startDate: startOfMonth,
+                endDate: endOfMonth,
+              );
           if (googleEvents.isNotEmpty) {
-            final results = await _googleCalendarService.deleteMultipleEventsFromGoogle(googleEvents);
+            final results = await _googleCalendarService
+                .deleteMultipleEventsFromGoogle(googleEvents);
             final successCount = results.values.where((v) => v).length;
-            print('✅ $successCount개 삭제 완료, ${results.length - successCount}개 삭제 실패');
+            print(
+              '✅ $successCount개 삭제 완료, ${results.length - successCount}개 삭제 실패',
+            );
           }
         } catch (e) {
           print('⚠️ 구글 캘린더 초기화 중 오류: $e');
@@ -553,22 +762,43 @@ class EventManager {
       }
       List<Event> localEvents = [];
       for (int day = startOfMonth.day; day <= endOfMonth.day; day++) {
-        localEvents.addAll(_controller.getEventsForDay(DateTime(currentMonth.year, currentMonth.month, day)).where((e) => e.source == 'local'));
+        localEvents.addAll(
+          _controller
+              .getEventsForDay(
+                DateTime(currentMonth.year, currentMonth.month, day),
+              )
+              .where((e) => e.source == 'local'),
+        );
       }
-      final List<Event> googleEvents = await _googleCalendarService.getEventsFromGoogleCalendar(startDate: startOfMonth, endDate: endOfMonth);
+      final List<Event> googleEvents = await _googleCalendarService
+          .getEventsFromGoogleCalendar(
+            startDate: startOfMonth,
+            endDate: endOfMonth,
+          );
       int uploadedCount = 0, skippedCount = 0;
       for (var localEvent in localEvents) {
-        if (googleEvents.any((g) => g.title == localEvent.title && g.date.isAtSameMomentAs(localEvent.date) && g.time == localEvent.time)) {
+        if (googleEvents.any(
+          (g) =>
+              g.title == localEvent.title &&
+              g.date.isAtSameMomentAs(localEvent.date) &&
+              g.time == localEvent.time,
+        )) {
           skippedCount++;
           continue;
         }
         try {
-          final googleEventId = await _googleCalendarService.addEventToGoogleCalendar(localEvent);
+          final googleEventId = await _googleCalendarService
+              .addEventToGoogleCalendar(localEvent);
           if (googleEventId != null) {
             uploadedCount++;
             try {
-              final updatedEvent = localEvent.copyWith(googleEventId: googleEventId);
-              await EventStorageService.removeEvent(localEvent.date, localEvent);
+              final updatedEvent = localEvent.copyWith(
+                googleEventId: googleEventId,
+              );
+              await EventStorageService.removeEvent(
+                localEvent.date,
+                localEvent,
+              );
               await EventStorageService.addEvent(localEvent.date, updatedEvent);
               _controller.removeEvent(localEvent);
               _controller.addEvent(updatedEvent);
@@ -580,7 +810,9 @@ class EventManager {
           print('❌ 업로드 중 오류: ${localEvent.title} - $e');
         }
       }
-      print('📊 Google Calendar 업로드 완료:\n   • 신규 업로드: $uploadedCount개\n   • 중복으로 건너뜀: $skippedCount개\n   • 총 로컬 이벤트: ${localEvents.length}개');
+      print(
+        '📊 Google Calendar 업로드 완료:\n   • 신규 업로드: $uploadedCount개\n   • 중복으로 건너뜀: $skippedCount개\n   • 총 로컬 이벤트: ${localEvents.length}개',
+      );
       await _googleCalendarService.syncColorMappingsToController(_controller);
     } catch (e) {
       print('❌ Google Calendar 업로드 중 오류: $e');
@@ -594,7 +826,11 @@ class EventManager {
       await EventStorageService.cleanupAllDuplicateEvents();
       final today = DateTime.now();
       await loadEventsForMonth(today);
-      final localEvents = _controller.getEventsForDay(today).where((e) => e.source == 'local').toList();
+      final localEvents =
+          _controller
+              .getEventsForDay(today)
+              .where((e) => e.source == 'local')
+              .toList();
       print('📊 초기 로드 완료 - 오늘 날짜 로컬 일정: ${localEvents.length}개');
       if (localEvents.isNotEmpty) {
         print('💾 저장된 로컬 일정들:');
@@ -627,7 +863,11 @@ class EventManager {
       final startOfYear = DateTime(now.year, 1, 1);
       final endOfYear = DateTime(now.year, 12, 31);
       int migratedCount = 0;
-      for (DateTime currentDate = startOfYear; currentDate.isBefore(endOfYear.add(const Duration(days: 1))); currentDate = currentDate.add(const Duration(days: 1))) {
+      for (
+        DateTime currentDate = startOfYear;
+        currentDate.isBefore(endOfYear.add(const Duration(days: 1)));
+        currentDate = currentDate.add(const Duration(days: 1))
+      ) {
         final events = await EventStorageService.getEvents(currentDate);
         bool hasChanges = false;
         for (var event in events) {


### PR DESCRIPTION
- 앱 저장소가 초기화 되고 나서 첫 실행 시 구간 이벤트의 첫날에만 일반 일정으로 불러오던 문제 수정
- (구글 캘린더의 이벤트를 최초로 불러올 때 구간 이벤트를 인식하지 못 하던 문제 수정)
- 같은 구간 이벤트가 같은 높이를 차지하도록 수정
- 구간 이벤트가 길이 순으로 정렬되도록 수정함: 날짜별로 낭비되는 셀 최소화
- 구간 이벤트 삭제가 올바르게 되지 않던 문제, 삭제되고 나서 셀이 새로고침되지 않던 문제 수정