### PR TITLE
브리핑 기능 수정

### DIFF
--- a/lib/models/daily_briefing.dart
+++ b/lib/models/daily_briefing.dart
@@ -65,10 +65,20 @@ class DailyBriefing {
         date.day == other.day;
   }
 
-  // 브리핑이 유효한지 확인 (같은 날짜이고 6시간 이내에 생성된 경우)
+  // 브리핑이 유효한지 확인 (브리핑 날짜와 현재 날짜 기준으로 판단)
   bool isValid() {
     final now = DateTime.now();
     final timeDifference = now.difference(createdAt).inHours;
-    return isSameDate(now) && timeDifference <= 6;
+
+    // 브리핑 날짜가 오늘이거나 내일이고, 24시간 이내에 생성된 경우 유효
+    final today = DateTime(now.year, now.month, now.day);
+    final tomorrow = today.add(Duration(days: 1));
+    final briefingDate = DateTime(date.year, date.month, date.day);
+
+    final isDateValid =
+        briefingDate.isAtSameMomentAs(today) ||
+        briefingDate.isAtSameMomentAs(tomorrow);
+
+    return isDateValid && timeDifference <= 24; // 24시간 이내로 확장
   }
 }


### PR DESCRIPTION
- 미리보기 버튼을 누를 때 예약된 브리핑이 없을 경우 만들어내서 미리보기에 띄우는 대신 없으면 없다고 표시하도록 수정
- 오늘, 내일 브리핑이 전부 없을 때 저장 버튼을 누르도록 안내문 추가
- 브리핑 알림을 켜고 저장했는데, 팝업을 나갔다 오면 저장이 풀려있는 문제 수정
- 브리핑 프롬프트 수정: 더 자연스러운 문장을 출력하고, 일정이 없는 경우 휴식 권장하는 프롬프트 추가
- 과거 날짜 브리핑 데이터가 제거되지 않아 새 브리핑을 생성하지 못해서 알림이 오지 않던 문제 수정